### PR TITLE
fix: fix a flaky test

### DIFF
--- a/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
+++ b/undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java
@@ -124,7 +124,7 @@ public abstract class AbstractUndertowSubsystemTestCase extends AbstractSubsyste
         Host host = (Host) awaitServiceValue(hostSC);
         if (flag == 1) {
             Assert.assertEquals(3, host.getAllAliases().size());
-            Assert.assertEquals("default-alias", new ArrayList<>(host.getAllAliases()).get(1));
+            Assert.assertTrue("default-alias should be present", new ArrayList<>(host.getAllAliases()).contains("default-alias"));
         }
 
         final ServiceName locationServiceName = UndertowService.locationServiceName(virtualHostName, "default-virtual-host", "/");


### PR DESCRIPTION
The function `getAllAliases()` from `Host` returns a list of strings that contains all the aliases of a host. There is no guarantee in order of the returned array of fields. Therefore, it causes a flaky test when running `mvn -pl undertow edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.wildfly.extension.undertow.UndertowSubsystemTestCase#testRuntime`. Here is the affected test:

`undertow/src/test/java/org/wildfly/extension/undertow/AbstractUndertowSubsystemTestCase.java`
```java
Assert.assertEquals("default-alias", new ArrayList<>(host.getAllAliases()).get(1));
```

This PR proposes to simply check whether `default-alias` exists in all aliases rather than checking index 1 in the string list so that the test cases will not fail because of the order in the string list.
